### PR TITLE
Support Gitlab CI

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -1,0 +1,23 @@
+pages:
+  stage: deploy
+  image: julia:1
+  script:
+    - cd generate
+    - cp generate.jl generate2.jl
+    - julia -e '
+          import Pkg;
+          Pkg.add("Pluto"); import Pluto;
+          Pluto.activate_notebook_environment("generate2.jl");
+          Pkg.instantiate();
+          include("generate.jl")'
+    - cd ..
+    - mv ./website/__site public
+  artifacts:
+    paths:
+      - public
+  rules:
+      - if: $CI_COMMIT_BRANCH == $CI_DEFAULT_BRANCH
+  cache:
+    paths:
+      - pluto_state_cache
+


### PR DESCRIPTION
Using Gitlab can be nice because it allows restricting Gitlab pages to project members. That way you can use this setup as a log for research projects.